### PR TITLE
Fixed issue where dir cpi was found as `warden_cpi' not `warden'

### DIFF
--- a/templates/make_manifest
+++ b/templates/make_manifest
@@ -17,7 +17,7 @@ shift
 
 BOSH_STATUS=$(bosh status)
 DIRECTOR_UUID=$(echo "$BOSH_STATUS" | grep UUID | awk '{print $2}')
-DIRECTOR_CPI=$(echo "$BOSH_STATUS" | grep CPI | awk '{print $2}')
+DIRECTOR_CPI=$(echo "$BOSH_STATUS" | grep CPI | awk '{print $2}' | sed -e 's/_cpi//')
 DIRECTOR_NAME=$(echo "$BOSH_STATUS" | grep Name | awk '{print $2}')
 NAME=$template_prefix-$infrastructure
 


### PR DESCRIPTION
`bosh upload stemcell ${STEMCELL_URL}` was failing because `${STEMCELL_URL}` was empty. The reason it was empty is because the `${DIRECTOR_CPI}` for warden was coming back as `warden_cpi` rather than `warden` and there are no stemcells containing `warden_cpi` in the name.