### PR TITLE
Allow agent-pgtools to be added ex post facto

### DIFF
--- a/jobs/agent-pgtools/spec
+++ b/jobs/agent-pgtools/spec
@@ -2,5 +2,6 @@
 name: agent-pgtools
 packages:
   - postgres-9.4
-templates: {}
+templates:
+  ignore: ignore
 properties: {}

--- a/jobs/agent-pgtools/templates/ignore
+++ b/jobs/agent-pgtools/templates/ignore
@@ -1,0 +1,2 @@
+# this file exists because BOSH cannot handle a
+# job that doesn't define at least one template


### PR DESCRIPTION
There is a bug in BOSH (or maybe a design/feature?) that won't allow
jobs without file templates to be applied to an existing VM.  Adding an
ignored template to the job fixes this.