### PR TITLE
Added recovery mode for shield-agent for emergency restores

### DIFF
--- a/jobs/shield-agent/spec
+++ b/jobs/shield-agent/spec
@@ -11,6 +11,7 @@ templates:
   bin/ctl: bin/ctl
   bin/monit_debugger: bin/monit_debugger
   bin/post-start.erb: bin/post-start
+  bin/emergency-recovery.erb: bin/emergency-recovery
   config/target.json.erb: config/target.json
   config/shield-agent.conf.erb: config/shield-agent.conf
   data/properties.sh.erb: data/properties.sh
@@ -28,10 +29,17 @@ properties:
   shield.agent.authorize_generated_daemon_key:
     description: "permit access via generated worker key, local to deployment"
     default: true
-
-
   shield.agent.autoprovision:
     description: "HTTP API of the Shield installation to automatically provision authorized keys from"
+  shield.agent.recovery.target_plugin:
+    description: "Target plugin to use in emergency-recovery-mode"
+  shield.agent.recovery.target_config:
+    description: "A map of key-values that will be converted to JSON, representing the target plugin configration"
+  shield.agent.recovery.store_plugin:
+    description: "Store plugin to use in emergency-recovery-mode"
+  shield.agent.recovery.store_config:
+    description: "A map of key-values that will be converted to JSON, representing the store plugin configration"
+
   shield.log_level:
     description: "Log level for shield processes"
     default: "info"

--- a/jobs/shield-agent/templates/bin/emergency-recovery.erb
+++ b/jobs/shield-agent/templates/bin/emergency-recovery.erb
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+export SHIELD_OP='restore'
+<% if_p("shield.agent.recovery.target_config") do |target_config| %>
+export SHIELD_TARGET_ENDPOINT=<%= target_config.to_json.dump %>
+<% end %>
+<% if_p("shield.agent.recovery.store_config") do |store_config| %>
+export SHIELD_STORE_ENDPOINT=<%= store_config.to_json.dump %>
+<% end %>
+<% if_p("shield.agent.recovery.store_plugin") do |store_plugin| %>
+export SHIELD_STORE_PLUGIN=/var/vcap/packages/plugins/bin/<%= store_plugin %>
+<% end %>
+<% if_p("shield.agent.recovery.target_plugin") do |target_plugin| %>
+export SHIELD_TARGET_PLUGIN=/var/vcap/packages/plugins/bin/<%= target_plugin %>
+<% end %>
+export SHIELD_RESTORE_KEY=$1
+shift
+
+if [[ -z $SHIELD_OP ]]; then
+	echo "No SHIELD_OP environment variable specified. Cannot continue."
+	exit 1
+fi
+if [[ -z $SHIELD_STORE_ENDPOINT ]]; then
+	echo "No SHIELD_STORE_ENDPOINT environment variable specified. Cannot continue."
+	exit 1
+fi
+if [[ -z $SHIELD_STORE_PLUGIN ]]; then
+	echo "No SHIELD_STORE_PLUGIN environment variable specified. Cannot continue."
+	exit 1
+fi
+if [[ -z $SHIELD_TARGET_ENDPOINT ]]; then
+	echo "No SHIELD_TARGET_ENDPOINT environment variable specified. Cannot continue."
+	exit 1
+fi
+if [[ -z $SHIELD_TARGET_PLUGIN ]]; then
+	echo "No SHIELD_TARGET_PLUGIN environment variable specified. Cannot continue."
+	exit 1
+fi
+if [[ -z $SHIELD_RESTORE_KEY ]]; then
+	echo "Usage: emergency-recovery <store key of archive you wish to restore>"
+	echo "       <store key> is typically the full path to the archive file in the store"
+fi
+
+for dir in /var/vcap/packages/*/bin; do
+	export PATH=${dir}:${PATH}
+done
+
+echo Restoring Data...
+/var/vcap/packages/plugins/bin/shield-pipe
+
+echo Restarting all services via monit, you may be prompted for a sudo password here
+sudo /var/vcap/bosh/bin/monit restart all


### PR DESCRIPTION
To aid in restoring things like BOSH + SHIELD databases in an
emergency situation, an emergency-recovery script was added, which
uses properties in `shield.agent.recovery.*` and the `store_key` of
the archive to restore, provided by the user.

This is intended as a manual emergency restore. You deploy BOSH,
or SHIELD, and ssh into the node, then run this script manually,
providing the archive's `store_key` as the only argument.

The script will then run `shield-pipe`, provided things have been
configured properly, and it will restore your data from backup,
without the need for a working SHIELD installation that knows about
all of your archives.

If it wasn't clear already, this script is intended to be used
IN EMERGENCY SITUATIONS ONLY, to RESTORE data.