### PR TITLE
make shield-agent to accept custom binary paths

### DIFF
--- a/jobs/shield-agent/spec
+++ b/jobs/shield-agent/spec
@@ -33,6 +33,11 @@ properties:
     description: "Store plugin to use in emergency-recovery-mode"
   shield.agent.recovery.store_config:
     description: "A map of key-values that will be converted to JSON, representing the store plugin configration"
+  shield.agent.plugin_paths:
+    description: "Map of paths that the binary of the plugins can be found"
+    example: |
+      plugin_paths:
+        atmos: /var/vcap/packages/atmos-plugin/bin
 
   shield.log_level:
     description: "Log level for shield processes"

--- a/jobs/shield-agent/templates/config/shield-agent.conf.erb
+++ b/jobs/shield-agent/templates/config/shield-agent.conf.erb
@@ -4,3 +4,8 @@ host_key_file: /etc/ssh/ssh_host_rsa_key
 listen_address: 0.0.0.0:<%= properties.shield.agent.port %>
 plugin_paths:
   - /var/vcap/packages/plugins/bin
+<% if_p("shield.agent.plugin_paths") do |tokens| %>
+<% tokens.each do |k, v| %>
+  - <%= v %>
+<% end %>
+<% end %>


### PR DESCRIPTION
Hi, 
we have a modified version of the S3 plugin to support our custom S3 storage, and we need to collocate two bosh releases. For that reason we need the config file of the shield-agent not to static, and recognise binaries in other location.