### PR TITLE
Add Timeout for Public Key Retrieval in agent start script

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,6 @@
+# Bug Fixes
+
+- Add a timeout of 20 seconds to the curl call that retrieves the
+  public key from the SHIELD core, to avoid deadlock conditions
+  that arise when the start script cannot access the core, either
+  due to networking issues, naming problems, or firewall / ACLs.

--- a/jobs/shield-agent/templates/bin/ctl
+++ b/jobs/shield-agent/templates/bin/ctl
@@ -19,7 +19,7 @@ case $1 in
     {
 <% if_p("shield.agent.autoprovision") do |endpoint| %>
       set +e
-      curl -Lks "<%= endpoint %>/v1/meta/pubkey"
+      curl -Lks "<%= endpoint %>/v1/meta/pubkey" -m 20
       set -e
 <% end %>
 <% if_p("shield.agent.daemon_public_key") do |key| %>


### PR DESCRIPTION
The agent now enforces a 20 second timeout when retrieving the public
key from the SHIELD core, to avoid deadlock conditions that arise when
the start script cannot access the core, either due to networking
issues, naming problems, or firewall / ACLs.