### PR TITLE
fix warden test to one that actually tests if the cpi is warden

### DIFF
--- a/templates/make_manifest
+++ b/templates/make_manifest
@@ -71,7 +71,7 @@ DIRECTOR_CPI=$(echo "$BOSH_STATUS" | grep CPI | awk '{print $2}' | sed -e 's/_cp
 DIRECTOR_NAME=$(echo "$BOSH_STATUS" | grep Name | awk '{print $2}')
 NAME=$template_prefix-$infrastructure
 
-if [[ $DIRECTOR_NAME = "warden" && ${infrastructure} != "warden" ]]; then
+if [[ $infrastructure == "warden" && ${DIRECTOR_CPI} != "warden" ]]; then
   fail "Not targeting bosh-lite with warden CPI. Please make sure you have run 'bosh target' and are targeting a BOSH lite before running this script."
   exit 1
 fi


### PR DESCRIPTION
the old test:
```bash
if [[ $DIRECTOR_NAME = "warden" && ${infrastructure} != "warden" ]]; then
```
my bosh lite:

```
[~/workspace/shield-boshrelease] (infra-aws)seth$ bosh status | grep Name
  Name       Bosh Lite Director
```

the test will succeed and go to the fail only when the director name is exactly 'warden' and the infratructure isn't warden.

The new test is 

```bash
if [[ $infrastructure == "warden" && ${DIRECTOR_CPI} != "warden" ]]; then
```

which is the same syntax as the aws test below it, and should correctly guard against a warden deployment in, say, an aws environment.