### PR TITLE
Ensure that the postgres plugin finds the bin_dir by default

### DIFF
--- a/jobs/postgres/templates/bin/postgres_start.sh
+++ b/jobs/postgres/templates/bin/postgres_start.sh
@@ -21,6 +21,12 @@ if [ -d $DATA_DIR -a -f $STORE_DIR/FLAG_POSTGRES_UPGRADE ]; then
   exit 1
 fi
 
+
+# Ensure that default postgres bin_dir of the postgres plugin is able to locate the bin_dir
+if [ ! -d $PACKAGE_DIR ]; then
+  ln -s $PACKAGE_DIR $PACKAGE_DIR_OLD
+fi
+
 sysctl -w "kernel.shmmax=284934144"
 
 if [ ! -d $STORE_DIR ]; then


### PR DESCRIPTION
The shield postgres plugin expects the bin_dir to be located at
/var/vcap/packages/postgres/bin. The shield-boshrelease agent-pgtools
job will put the bin_dir to /var/vcap/packages/postgres9.4/bin.

The change in the init script will check if the default bin_dir
exists and if not, it will create a symlink to the one of the
shield-boshrelease agent-pgtools.