### PR TITLE
Correct test if postgres dir exists

### DIFF
--- a/jobs/postgres/templates/bin/postgres_start.sh
+++ b/jobs/postgres/templates/bin/postgres_start.sh
@@ -23,7 +23,7 @@ fi
 
 
 # Ensure that default postgres bin_dir of the postgres plugin is able to locate the bin_dir
-if [ ! -d $PACKAGE_DIR ]; then
+if [ ! -d $PACKAGE_DIR_OLD ]; then
   ln -s $PACKAGE_DIR $PACKAGE_DIR_OLD
 fi
 


### PR DESCRIPTION
The bash `test` was wrong since the `ln` syntax is `ln $existing $the-link` and if 

`ln -s $PACKAGE_DIR $PACKAGE_DIR_OLD` we need to check if `$PACKAGE_DIR_OLD` does not exist already.

Thx + props to @szaouam for finding this.