### PR TITLE
nginx: preserve host information on redirect

### DIFF
--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -45,7 +45,7 @@ http {
     listen <%= p('shield.daemon.http_port') %>;
     server_name  _;
     ssl off;
-    return 301 https://<%= p('shield.daemon.domain') %>:<%= p('shield.daemon.port') %>$request_uri;
+    return 301 https://$host$request_uri;
   }
 
   server {


### PR DESCRIPTION
Tested on AWS with bosh-lite.