### PR TITLE
Fix call to `shield-pipe` in the `emergency-recovery` script

### DIFF
--- a/jobs/shield-agent/templates/bin/emergency-recovery
+++ b/jobs/shield-agent/templates/bin/emergency-recovery
@@ -46,7 +46,7 @@ for dir in /var/vcap/packages/*/bin; do
 done
 
 echo Restoring Data...
-/var/vcap/packages/plugins/bin/shield-pipe
+shield-pipe
 
 echo Restarting all services via monit, you may be prompted for a sudo password here
 sudo /var/vcap/bosh/bin/monit restart all


### PR DESCRIPTION
Hi,

The `emergency-recovery` script fails at calling the `shield-pipe` script because it is in the `shield` package instead of the `plugins` package.

As the `emergency-recovery` script already builds a custom PATH over all the packages `./bin` directories, there is apparently no need for specifying the whole path when calling `shield-pipe`.

Thus the following patch.

Cheers