### PR TITLE
Fix v6 CI error, replace rootfs_uri with image_resource

### DIFF
--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -117,7 +117,10 @@ jobs:
     - task: testflight
       config:
         platform: linux
-        rootfs_uri: docker:///starkandwayne/concourse
+        image_resource:
+          type: docker-image
+          source:
+            repository: (( grab meta.image ))
         inputs:
           - { name: git-6.x, path: git }
         run:


### PR DESCRIPTION
Original error example https://ci.starkandwayne.com/teams/main/pipelines/shield-boshrelease/jobs/testflight-6.x/builds/7

Working https://ci.starkandwayne.com/teams/main/pipelines/shield-boshrelease/jobs/testflight-6.x/builds/10