### PR TITLE
Expose Timeout,Workers to shield-daemon config

### DIFF
--- a/jobs/shield-daemon/spec
+++ b/jobs/shield-daemon/spec
@@ -44,6 +44,12 @@ properties:
     default: 443
   domain:
     description: Fully-qualified domain name (or IP address) of your SHIELD installation
+  workers:
+    description: Max number of concurrent tasks in running state.
+    default: 5
+  max_timeout:
+    description: Duration in hours after which a running task is timed out.
+    default: 12
 
   ssl.key:
     description: "TLS private key (PEM encoded)"

--- a/jobs/shield-daemon/templates/config/shieldd.conf
+++ b/jobs/shield-daemon/templates/config/shieldd.conf
@@ -45,6 +45,8 @@ database_dsn: "<%= shielddb_uri %>"
 listen_addr: 0.0.0.0:8080
 private_key: /var/vcap/jobs/shield-daemon/shared/id_rsa
 web_root: /var/vcap/packages/shield/webui
+workers: <%= p('workers') %>
+max_timeout: <%= p('max_timeout') %>
 
 
 auth:


### PR DESCRIPTION
Here is a small pull request to resolve #88 

I proposed that the variables are always written to the config file of shield-daemon so that the (default) values are easily visible to the operator. The alternative would have been the vars not to be there, in which case the operator should look the shield codebase to see the default values.

Not sure if the description `Max number of concurrent tasks in running state` is accurate.

Thx