### PR TITLE
Enable shield deployment with mariadb as db

### DIFF
--- a/jobs/mariadb/spec
+++ b/jobs/mariadb/spec
@@ -9,20 +9,25 @@ templates:
   bin/mariadb_start.sh:  bin/mariadb_start.sh
   config/my.cnf:         config/my.cnf
 
+provides:
+- name: db
+  type: sql
+  properties:
+  - port
+  - db_scheme
+  - roles
+  - databases
+
 properties:
-  databases.port:
+  port:
     description: MySQL port to bind.
     default: 3306
 
-  databases.databases:
-    description: |
-      A list of databases to provision.
-      Each entry in the list must be a map with the 'name' key set, i.e.:
-        databases:
-          databases:
-            - name: shielddb
+  db_scheme:
+    description: Link property to declare it as mysql://
+    default: mysql
 
-  databases.roles:
+  roles:
     description: |
       A list of database users (roles) to create.  All users created will have full access to all databases.
       Each entry in the list must be a map with 'name' and 'password' keys, a la:
@@ -30,3 +35,11 @@ properties:
           roles:
             - name:     shieldadmin
               password: its-a-secret
+
+  databases:
+    description: |
+      A list of databases to provision.
+      Each entry in the list must be a map with the 'name' key set, i.e.:
+        databases:
+          databases:
+            - name: shielddb

--- a/jobs/mariadb/templates/bin/mariadb_start.sh
+++ b/jobs/mariadb/templates/bin/mariadb_start.sh
@@ -8,7 +8,7 @@ SERVER=$PACKAGE_DIR/support-files/mysql.server
 RUN_DIR=/var/vcap/sys/run/mariadb
 PIDFILE=$RUN_DIR/mariadb.pid
 
-PORT=<%= p('databases.port') %>
+PORT=<%= p('port') %>
 
 if [ ! -d $STORE_DIR ]; then
   echo "ERROR: storage directory doesn't exist"
@@ -31,7 +31,7 @@ su - vcap -c "$SERVER start --datadir=$DATA_DIR --basedir=$PACKAGE_DIR --pid-fil
 su - vcap -c "echo \"DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');\" | $PACKAGE_DIR/bin/mysql --port $PORT -u root"
 
 echo "Creating roles..."
-<% p("databases.roles", []).each do |role| %>
+<% p("roles", []).each do |role| %>
   echo "Trying to create role <%= role["name"] %>..."
   set +e
   su - vcap -c "echo \"GRANT ALL PRIVILEGES ON *.* TO '<%= role["name"] %>'@'%' IDENTIFIED BY '<%= role["password"] %>'; FLUSH PRIVILEGES;\" | $PACKAGE_DIR/bin/mysql --port $PORT -u root"
@@ -39,7 +39,7 @@ echo "Creating roles..."
 <% end %>
 
 echo "Creating databases..."
-<% p("databases.databases", []).each do |database| %>
+<% p("databases", []).each do |database| %>
   echo "Trying to create database <%= database["name"] %>..."
   set +e
   su - vcap -c "$PACKAGE_DIR/bin/mysqladmin --port $PORT -u root create <%= database["name"] %>"

--- a/jobs/mariadb/templates/config/my.cnf
+++ b/jobs/mariadb/templates/config/my.cnf
@@ -1,4 +1,4 @@
 [mysqld]
 bind-address=0.0.0.0
-port=<%= p('databases.port') %>
+port=<%= p('port') %>
 log_error=/var/vcap/sys/log/mariadb/error.log

--- a/manifests/examples/creds.yml
+++ b/manifests/examples/creds.yml
@@ -11,7 +11,7 @@
 #       They are excellent for setting up SHIELD for evaluation
 #       purposes, but don't run them in production.
 
-postgress-password: dbpass
+db-password: dbpass
 shield-daemon-sshkey:
   private_key: |
     -----BEGIN RSA PRIVATE KEY-----

--- a/manifests/operators/use-mariadb.yml
+++ b/manifests/operators/use-mariadb.yml
@@ -1,0 +1,17 @@
+---
+- type: remove
+  path: /instance_groups/name=shield/jobs/name=postgres
+
+- type: replace
+  path: /instance_groups/name=shield/jobs/-
+  value:
+    name: mariadb
+    release: shield
+    properties:
+      databases:
+      - {name: shielddb,   tag: shield,   citext: true}
+      - {name: sessionsdb, tag: sessions, citext: true}
+      roles:
+      - name: shieldadmin
+        password: ((db-password))
+        tag: admin

--- a/manifests/shield.yml
+++ b/manifests/shield.yml
@@ -17,7 +17,7 @@ instance_groups:
       - {name: sessionsdb, tag: sessions, citext: true}
       roles:
       - name: shieldadmin
-        password: ((postgres-password))
+        password: ((db-password))
         tag: admin
   - name: shield-daemon
     release: shield
@@ -43,7 +43,7 @@ instance_groups:
       retention-policies: {default: 30}
 
 variables:
-- name: postgres-password
+- name: db-password
   type: password
 - name: shield-daemon-sshkey
   type: rsa


### PR DESCRIPTION
Here is a pull request to allow deploying shield with mariadb as backend database.
The mariadb job, as well as the manifest were not updated with the new way of deployment.

With this changes we can deploy shield with mariadb as follows:
```
 bosh deploy manifests/shield.yml -o manifests/operators/use-mariadb.yml 
```

This change
```
-- name: postgres-password		
+- name: db-password
```
is the only change outside mariadb related code, and it might create issues if it is being used somewhere (ci) else hardcoded.

#94 

Thx!