### PR TITLE
Make sql link optional

### DIFF
--- a/jobs/shield-daemon/spec
+++ b/jobs/shield-daemon/spec
@@ -30,6 +30,7 @@ provides:
 consumes:
 - name: shield-db
   type: sql
+  optional: true
 - name: sessions-db
   type: sql
   optional: true


### PR DESCRIPTION
In deployments that depend on external database, there is no
component offering a link of type `sql`, therefore the deployment
is failing.

From what I can see there is no reason not to have this link optional.

It would be nice that we can align the links with external databases. I am not sure if that is possible.
For example, postgres bosh release is offering of type [database](https://github.com/cloudfoundry/postgres-release/blob/develop/jobs/postgres/spec#L25) or mysql of type [mysl](https://github.com/cloudfoundry/cf-mysql-release/blob/develop/jobs/mysql/spec#L47)


 #93 