### PR TITLE
Empty string fallback for `spec.name` when using bosh create-env

### DIFF
--- a/jobs/shield-agent/templates/config/agent.conf
+++ b/jobs/shield-agent/templates/config/agent.conf
@@ -1,6 +1,6 @@
 ---
 name: <%= p('name').gsub('(deployment)', spec.deployment)
-                   .gsub('(name)',       spec.name)
+                   .gsub('(name)',       spec.name || '')
                    .gsub('(az)',         spec.az || '')
                    .gsub('(index)',      spec.index.to_s) %>
 authorized_keys_file: /var/vcap/jobs/shield-agent/config/authorized_keys


### PR DESCRIPTION
addresses #104 