### PR TITLE
Make HTTP -> HTTPS redirect optional

### DIFF
--- a/jobs/core/spec
+++ b/jobs/core/spec
@@ -35,6 +35,9 @@ properties:
   port:
     description: Incoming port to bind for HTTPS API and Web UI
     default: 443
+  enable_http_redirect:
+    description: Redirect HTTP to HTTPS
+    default: true
 
   core.env:
     description: A short tag describing this environment (i.e. 'prod', 'staging', etc.).

--- a/jobs/core/templates/config/nginx.conf
+++ b/jobs/core/templates/config/nginx.conf
@@ -50,12 +50,14 @@ http {
     ''      close;
   }
 
+  <% if_p('enable_http_redirect') do %>
   server {
     listen 80;
     server_name  _;
     ssl off;
     return 301 https://$host$request_uri;
   }
+  <% end %>
 
   server {
     listen <%= p('port') %>;


### PR DESCRIPTION
While trying to integrate shield with bucc I encountered an port conflict. And since I could not think of a usecase for wanting to listing on a different port for HTTP I opted for making the whole redirect optional.