### PR TITLE
Correct agent.key setting

### DIFF
--- a/jobs/shield-agent/spec
+++ b/jobs/shield-agent/spec
@@ -30,7 +30,7 @@ properties:
     default: 5444
 
   agent.key:
-    description: RSA private key used for securing communications between SHIELD Agents and the SHIELD Core.
+    description: SSH public key used for securing communications between SHIELD Agents and the SHIELD Core.
   core.ca:
     description: The PEM-encoded certificate of the CA that signed the Shield Certificate.  The SHIELD agent needs this so that it can trust the Shield-Core certificate.
 


### PR DESCRIPTION
The `agent.key` property on the `agent` needs to be an SSH Public Key as can be validated in: https://github.com/starkandwayne/shield-boshrelease/blob/master/jobs/shield-agent/templates/config/agent.key

Maybe it would make sense to change the property name to `agent.publickey`.