### PR TITLE
Fix bug which led to unboud variable forced by set -u

### DIFF
--- a/jobs/shield-agent/templates/bin/shield-agent
+++ b/jobs/shield-agent/templates/bin/shield-agent
@@ -65,7 +65,7 @@ case $1 in
         PATH="$PATH:$pkg/sbin"
       fi
       if [[ -d $pkg/lib ]]; then
-        if [[ -z "$LD_LIBRARY_PATH" ]]; then
+        if [[ -z "${LD_LIBRARY_PATH+x}" ]]; then
           LD_LIBRARY_PATH="$pkg/lib"
         else
           LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$pkg/lib"
@@ -81,7 +81,7 @@ case $1 in
 
     <% if p('env.libs', []).size > 0 %>
     # env.libs
-    if [[ -z "$LD_LIBRARY_PATH" ]]; then
+    if [[ -z "${LD_LIBRARY_PATH+x}" ]]; then
       LD_LIBRARY_PATH="<%= p('env.libs').join(':') %>"
     else
       LD_LIBRARY_PATH="$LD_LIBRARY_PATH:<%= p('env.libs').join(':') %>"


### PR DESCRIPTION
When using set -u (and the init script is on set -eu) one can not
test a variable using [[ -z "$var" ]] because the var might be
_not_ set which will cause an exit 1.

This happens if someone tries to use the shield-mysql-addon with
LD_LIBRARY_PATH, the monit script exits with:
/var/vcap/jobs/shield-agent/bin/shield-agent:
line 53: LD_LIBRARY_PATH: unbound variable

Explaination: https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash
(i had to google... )