### PR TITLE
Added compatibility for v8 encryption update

### DIFF
--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -10,10 +10,10 @@ meta:
     path: ci/manifest.yml
 
   bosh-lite:
-    target: https://10.58.111.49:25555
-    username: (( vault "secret/bosh-lites/lite49/users/admin:username" ))
-    password: (( vault "secret/bosh-lites/lite49/users/admin:password" ))
-    cacert:   (( vault "secret/bosh-lites/lite49/certs:rootCA.pem" ))
+    target: https://10.58.111.44:25555
+    username: (( vault "secret/bosh-lites/lite44/users/admin:username" ))
+    password: (( vault "secret/bosh-lites/lite44/users/admin:password" ))
+    cacert:   (( vault "secret/bosh-lites/lite44/certs:rootCA.pem" ))
 
   bosh-lite-6x:
     target: https://10.58.111.44:25555

--- a/jobs/core/templates/bin/shieldd
+++ b/jobs/core/templates/bin/shieldd
@@ -33,6 +33,10 @@ case $1 in
     <%   end
        end %>
 
+    if [[ -f $DAT_DIR/main.db ]]; then
+        mv $DAT_DIR/main.db $DAT_DIR/shield.db
+    fi
+
     echo "$(date) running any schema migrations"
     chpst -u vcap:vcap \
       /var/vcap/packages/shield/bin/shield-schema \

--- a/jobs/core/templates/bin/shieldd
+++ b/jobs/core/templates/bin/shieldd
@@ -22,13 +22,13 @@ case $1 in
 
     <% if_p('migrate-from.type') do |type|
          if_p('migrate-from.dsn') do |dsn| %>
-    if [[ ! -f $DAT_DIR/main.db ]]; then
+    if [[ ! -f $DAT_DIR/shield.db ]]; then
       echo "$(date) migrating data from legacy storage"
       chpst -u vcap:vcap \
         /var/vcap/packages/shield/bin/shield-migrate \
           --type '<%= type %>' \
           --from '<%= dsn %>' \
-          --to $DAT_DIR/main.db
+          --to $DAT_DIR/shield.db
     fi
     <%   end
        end %>
@@ -36,7 +36,7 @@ case $1 in
     echo "$(date) running any schema migrations"
     chpst -u vcap:vcap \
       /var/vcap/packages/shield/bin/shield-schema \
-        -d $DAT_DIR/main.db
+        -d $DAT_DIR/shield.db
 
     echo "$(date) starting up shieldd (pid $$)"
     echo $$ > $PIDFILE

--- a/jobs/core/templates/config/shieldd.conf
+++ b/jobs/core/templates/config/shieldd.conf
@@ -33,7 +33,6 @@ session_timeout: <%= time_in_seconds('core.session-timeout', '5m', '90d') %>
 data_directory:  /var/vcap/store/shield
 vault_address:   https://127.0.0.1:8200
 vault_ca_cert:   /var/vcap/jobs/core/config/tls/vault.ca
-vault_keyfile:   /var/vcap/store/shield/vault.keys
 log_level:       <%= p('log-level') %>
 
 fast_loop:       <%= time_in_seconds('core.fast-loop', '2s', '5m') %>

--- a/jobs/core/templates/config/shieldd.conf
+++ b/jobs/core/templates/config/shieldd.conf
@@ -30,7 +30,7 @@ workers:         <%= p('core.workers') %>
 max_timeout:     <%= time_in_seconds('core.task-timeout',    '1h', '24h') %>
 session_timeout: <%= time_in_seconds('core.session-timeout', '5m', '90d') %>
 
-database:        /var/vcap/store/shield/main.db
+data_directory:  /var/vcap/store/shield
 vault_address:   https://127.0.0.1:8200
 vault_ca_cert:   /var/vcap/jobs/core/config/tls/vault.ca
 vault_keyfile:   /var/vcap/store/shield/vault.keys

--- a/manifests/shield.yml
+++ b/manifests/shield.yml
@@ -94,4 +94,6 @@ stemcells:
 
 releases:
 - name: shield
-  version: latest
+  version: 8.0.8
+  url: https://github.com/starkandwayne/shield-boshrelease/releases/download/v8.0.8/shield-8.0.8.tgz
+  sha1: 55d1d6d8557f9b185fef7b5c6d73017b4c654f03

--- a/manifests/shield.yml
+++ b/manifests/shield.yml
@@ -94,6 +94,4 @@ stemcells:
 
 releases:
 - name: shield
-  version: 8.0.8
-  url: https://github.com/starkandwayne/shield-boshrelease/releases/download/v8.0.8/shield-8.0.8.tgz
-  sha1: 55d1d6d8557f9b185fef7b5c6d73017b4c654f03
+  version: latest

--- a/packages/shield/packaging
+++ b/packages/shield/packaging
@@ -5,12 +5,13 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 tar -xzf shield/shield-server-linux-amd64*.tar.gz
 pushd shield-server-linux-amd64*/
-  cp agent/shield-agent   ${BOSH_INSTALL_TARGET}/bin
-  cp cli/shield           ${BOSH_INSTALL_TARGET}/bin
-  cp daemon/shieldd       ${BOSH_INSTALL_TARGET}/bin
-  cp daemon/shield-schema ${BOSH_INSTALL_TARGET}/bin
-  cp daemon/shield-pipe   ${BOSH_INSTALL_TARGET}/bin
+  cp agent/shield-agent    ${BOSH_INSTALL_TARGET}/bin
+  cp cli/shield            ${BOSH_INSTALL_TARGET}/bin
+  cp daemon/shieldd        ${BOSH_INSTALL_TARGET}/bin
+  cp daemon/shield-schema  ${BOSH_INSTALL_TARGET}/bin
+  cp daemon/shield-migrate ${BOSH_INSTALL_TARGET}/bin
   cp crypter/shield-crypt ${BOSH_INSTALL_TARGET}/bin
-  cp -R webui             ${BOSH_INSTALL_TARGET}/webui
-  cp -R plugins           ${BOSH_INSTALL_TARGET}/plugins
+  cp daemon/shield-pipe    ${BOSH_INSTALL_TARGET}/bin
+  cp -R webui              ${BOSH_INSTALL_TARGET}/webui
+  cp -R plugins            ${BOSH_INSTALL_TARGET}/plugins
 popd

--- a/packages/shield/packaging
+++ b/packages/shield/packaging
@@ -10,7 +10,7 @@ pushd shield-server-linux-amd64*/
   cp daemon/shieldd        ${BOSH_INSTALL_TARGET}/bin
   cp daemon/shield-schema  ${BOSH_INSTALL_TARGET}/bin
   cp daemon/shield-migrate ${BOSH_INSTALL_TARGET}/bin
-  cp crypter/shield-crypt ${BOSH_INSTALL_TARGET}/bin
+  cp crypter/shield-crypt  ${BOSH_INSTALL_TARGET}/bin
   cp daemon/shield-pipe    ${BOSH_INSTALL_TARGET}/bin
   cp -R webui              ${BOSH_INSTALL_TARGET}/webui
   cp -R plugins            ${BOSH_INSTALL_TARGET}/plugins

--- a/packages/shield/packaging
+++ b/packages/shield/packaging
@@ -10,6 +10,7 @@ pushd shield-server-linux-amd64*/
   cp daemon/shieldd       ${BOSH_INSTALL_TARGET}/bin
   cp daemon/shield-schema ${BOSH_INSTALL_TARGET}/bin
   cp daemon/shield-pipe   ${BOSH_INSTALL_TARGET}/bin
+  cp crypter/shield-crypt ${BOSH_INSTALL_TARGET}/bin
   cp -R webui             ${BOSH_INSTALL_TARGET}/webui
   cp -R plugins           ${BOSH_INSTALL_TARGET}/plugins
 popd


### PR DESCRIPTION
-Adds support for the upcoming shield v8 changed to encryption by adding the new shield-crypt binary to the bin directory

-Resolves encoding issues with shield-migrate so upgrades from mysql/postgres/maria now function properly

-Adds support for the new directory/config structure in the upcoming shield release

Note: This PR depends on a new release of SHIELD (likely 8.0.9) to include shield-migrate and the new encryption features as well as PR #401 on the SHIELD codebase to resolve the migration encoding.