### PR TITLE
Allow TLS/SSL ciphers/protocols to be configured

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Improvements
+
+- Add configuration value to change which ciphers and protocols the Nginx
+  reverse-proxy uses in SSL/TLS connections.

--- a/jobs/core/spec
+++ b/jobs/core/spec
@@ -82,6 +82,12 @@ properties:
   tls.reuse-after:
     description: "How long (in hours) before rotating cryptographic parameters"
     default: 2
+  tls.ciphers:
+    description: "Which SSL/TLS ciphers to allow, used for the HTTPS API and Web UI"
+    default: "ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:!MD5:!aNULL:!EDH"
+  tls.protocols:
+    description: "Which SSL/TLS protocols to allow, used for the HTTPS API and Web UI"
+    default: "TLSv1 TLSv1.1 TLSv1.2"
 
   agent.key:
     description: RSA private key used for securing communications between SHIELD Agents and the SHIELD Core.

--- a/jobs/core/templates/config/nginx.conf
+++ b/jobs/core/templates/config/nginx.conf
@@ -66,8 +66,8 @@ http {
 
     ssl                        on;
     ssl_prefer_server_ciphers  on;
-    ssl_protocols              TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers                ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:!MD5:!aNULL:!EDH;
+    ssl_protocols              <%= p('tls.protocols') %>;
+    ssl_ciphers                <%= p('tls.ciphers') %>;
     ssl_certificate            /var/vcap/jobs/core/config/tls/nginx.pub;
     ssl_certificate_key        /var/vcap/jobs/core/config/tls/nginx.key;
     ssl_session_timeout        <%= p('tls.reuse-after') %>;


### PR DESCRIPTION
We noticed some clients were having issues with the default hardcoded TLS ciphers we allowed on the Nginx reverse proxy. This PR adds the ability to override the default protocols & ciphers.