### PR TITLE
Add mysql as a backend for vault

### DIFF
--- a/jobs/core/spec
+++ b/jobs/core/spec
@@ -112,6 +112,14 @@ properties:
     description: The PEM-encoded certificate of the Vault itself.  This certificate should be issued for the IP SAN 127.0.0.1.
   vault.tls.key:
     description: The PEM-encoded private key for the Vault certificate.
+  vault.backend.mysql_address:
+    description: Vault Backend MySQL address
+  vault.backend.mysql_username:
+    description: Vault Backend MySQL username
+  vault.backend.mysql_password:
+    description: Vault Backend MySQL password
+  vault.backend.mysql_database:
+    description: Vault Backend MySQL database
 
   migrate-from.type:
     description: What type of legacy (pre-v8) database to migrate from (optional).

--- a/jobs/core/templates/config/vault.conf
+++ b/jobs/core/templates/config/vault.conf
@@ -1,9 +1,19 @@
 #disable_mlock = 1
-storage "file" {
-  path = "/var/vcap/store/shield/vault"
-}
 listener "tcp" {
   address       = "127.0.0.1:8200"
   tls_cert_file = "/var/vcap/jobs/core/config/tls/vault.pub"
   tls_key_file  = "/var/vcap/jobs/core/config/tls/vault.key"
 }
+
+<% if p('vault.backend.mysql_address', "") != "" %>
+storage "mysql" {
+  address  = "<%= p("vault.backend.mysql_address") %>"
+  username = "<%= p("vault.backend.mysql_username") %>"
+  password = "<%= p("vault.backend.mysql_password") %>"
+  database = "<%= p("vault.backend.mysql_database") %>"
+}
+<% else %>
+storage "file" {
+  path = "/vault/storage"
+}
+<% end %>


### PR DESCRIPTION
Add the option to add a database (mysql) to be the backend of the vault