### PR TITLE
Allow TLS/SSL ciphers/protocols to be configured for store job

### DIFF
--- a/jobs/store/spec
+++ b/jobs/store/spec
@@ -23,6 +23,12 @@ properties:
     description: TLS private key (PEM encoded), used for secure WebDAV.
   tls.certificate:
     description: TLS Certificate (PEM encoded), used for secure WebDAV.
+  tls.ciphers:
+    description: "Which SSL/TLS ciphers to allow, used for the HTTPS API and Web UI"
+    default: "ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:!MD5:!aNULL:!EDH"
+  tls.protocols:
+    description: "Which SSL/TLS protocols to allow, used for the HTTPS API and Web UI"
+    default: "TLSv1 TLSv1.1 TLSv1.2"
 
   webdav.browsable:
     description: Whether or not the WebDAV store is browsable.  Highly recommended for ease-of-operation.

--- a/jobs/store/templates/config/nginx.conf
+++ b/jobs/store/templates/config/nginx.conf
@@ -58,8 +58,8 @@ http {
 
     ssl                        on;
     ssl_prefer_server_ciphers  on;
-    ssl_protocols              TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers                ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:HIGH:!MD5:!aNULL:!EDH;
+    ssl_protocols              <%= p('tls.protocols') %>;
+    ssl_ciphers                <%= p('tls.ciphers') %>;
     ssl_certificate            /var/vcap/jobs/store/config/tls.pub;
     ssl_certificate_key        /var/vcap/jobs/store/config/tls.key;
     ssl_session_timeout        1;


### PR DESCRIPTION
This allows the TLS ciphers and protocols to be configured on the store job in a similar way to how these settings are configurable on the core job.

Signed-off-by: Kieran Robinson <krobn@allstate.com>