### PR TITLE
Fixes for shield recover

### DIFF
--- a/jobs/core/spec
+++ b/jobs/core/spec
@@ -112,3 +112,9 @@ properties:
     description: The PEM-encoded certificate of the Vault itself.  This certificate should be issued for the IP SAN 127.0.0.1.
   vault.tls.key:
     description: The PEM-encoded private key for the Vault certificate.
+
+  plugin_paths:
+    description: "Map of paths that the binary of the plugins can be found"
+    example: |
+      plugin_paths:
+        atmos: /var/vcap/packages/atmos-plugin/bin

--- a/jobs/core/templates/bin/shieldd
+++ b/jobs/core/templates/bin/shieldd
@@ -38,6 +38,7 @@ case $1 in
       /var/vcap/packages/shield/bin/shield-schema \
         -d $DAT_DIR/shield.db
 
+    export PATH=/var/vcap/packages/shield/bin:$PATH
     echo "$(date) starting up shieldd (pid $$)"
     echo $$ > $PIDFILE
     exec chpst -u vcap:vcap \

--- a/jobs/core/templates/config/shieldd.conf
+++ b/jobs/core/templates/config/shieldd.conf
@@ -23,8 +23,9 @@
     return v
   end
 %>
-web-root:  /var/vcap/packages/shield/webui
-data-dir:  /var/vcap/store/shield
+plugins-path: /var/vcap/packages/shield/plugins 
+web-root:     /var/vcap/packages/shield/webui
+data-dir:     /var/vcap/store/shield
 vault:
   address:   https://127.0.0.1:8200
   ca:        /var/vcap/jobs/core/config/tls/vault.ca

--- a/jobs/core/templates/config/shieldd.conf
+++ b/jobs/core/templates/config/shieldd.conf
@@ -23,7 +23,14 @@
     return v
   end
 %>
-plugins-path: /var/vcap/packages/shield/plugins 
+plugin_paths:
+  - /var/vcap/packages/shield/plugins
+<% if_p("plugin_paths") do |paths| %>
+<% paths.each do |k, path| %>
+  - <%= path %>
+<% end %>
+<% end %>
+
 web-root:     /var/vcap/packages/shield/webui
 data-dir:     /var/vcap/store/shield
 vault:


### PR DESCRIPTION
Changes in this pr:
- Added the shield recover binary path to the shieldd job.
- Added a configurable plugin_paths so shield core can use the fs plugin for shield-recover. 